### PR TITLE
[fix] Add unicode support

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -19,6 +19,12 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     return true
 })
 
+function unicodeToBase64(text){
+    const bytes = new TextEncoder().encode(text)
+    const binString = String.fromCodePoint(...bytes);
+    return btoa(binString);
+}
+
 function downloadTranscript() {
     chrome.storage.local.get(["transcript", "meetingTitle", "meetingStartTimeStamp"], function (result) {
         if (result.transcript) {
@@ -47,7 +53,7 @@ function downloadTranscript() {
             // Create a download
             // Use Chrome Download API
             chrome.downloads.download({
-                url: 'data:text/plain;base64,' + btoa(textContent),
+                url: 'data:text/plain;base64,' + unicodeToBase64(textContent),
                 filename: fileName,
                 conflictAction: 'uniquify' // Automatically rename the file if it already exists
             }).then(() => {

--- a/extension/background.js
+++ b/extension/background.js
@@ -19,12 +19,6 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     return true
 })
 
-function unicodeToBase64(text){
-    const bytes = new TextEncoder().encode(text)
-    const binString = String.fromCodePoint(...bytes);
-    return btoa(binString);
-}
-
 function downloadTranscript() {
     chrome.storage.local.get(["transcript", "meetingTitle", "meetingStartTimeStamp"], function (result) {
         if (result.transcript) {
@@ -53,7 +47,7 @@ function downloadTranscript() {
             // Create a download
             // Use Chrome Download API
             chrome.downloads.download({
-                url: 'data:text/plain;base64,' + unicodeToBase64(textContent),
+                url: 'data:text/plain;base64,' + encodeUnicodeString(textContent),
                 filename: fileName,
                 conflictAction: 'uniquify' // Automatically rename the file if it already exists
             }).then(() => {
@@ -61,7 +55,7 @@ function downloadTranscript() {
             }).catch((error) => {
                 console.log(error)
                 chrome.downloads.download({
-                    url: 'data:text/plain;base64,' + btoa(textContent),
+                    url: 'data:text/plain;base64,' + encodeUnicodeString(textContent),
                     filename: "TranscripTonic/Transcript.txt",
                     conflictAction: 'uniquify' // Automatically rename the file if it already exists
                 })
@@ -71,4 +65,11 @@ function downloadTranscript() {
         else
             console.log("No transcript found")
     })
+}
+
+// Thanks to @ifTNT(https://github.com/vivek-nexus/transcriptonic/pull/4)
+function encodeUnicodeString(text) {
+    const utf8Bytes = new TextEncoder().encode(text)
+    const binaryString = String.fromCodePoint(...utf8Bytes);
+    return btoa(binaryString);
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "TranscripTonic",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "manifest_version": 3,
   "description": "Simple Google Meet transcripts. Private and open source.",
   "action": {


### PR DESCRIPTION
Since `btoa` interprets the code points of its input string as byte values, calling `btoa` on a string will cause a "Character Out Of Range" exception if a character's code point exceeds 0xff.

This patch replaces the `btoa` with the recommended solution from MDN, which encodes the Unicode string to the single-byte representation before passing it to `btoa`.

Reference:
https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem